### PR TITLE
面談日程を承認or却下する機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,7 @@
     display: inline-block;
     width: auto;
 }
+
+p.box {
+    border-bottom: 1px solid;
+ }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,3 @@
     display: inline-block;
     width: auto;
 }
-
-p.box {
-    border-bottom: 1px solid;
- }

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -69,15 +69,13 @@ class InterviewsController < ApplicationController
   end
 
   def correct_user
-    interview = current_user.interviews.find_by(id: params[:id])
-    unless interview.present?
+    unless current_user.interviews.find_by(id: params[:id])
       redirect_to root_url
     end
   end
 
   def different_user
-    interview = current_user.interviews.find_by(id: params[:id])
-    if interview.present?
+    if current_user.interviews.find_by(id: params[:id])
       redirect_to root_url
     end
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -40,6 +40,9 @@ class InterviewsController < ApplicationController
     redirect_to user_interviews_path(@interview.user), notice: "面接日程を削除しました。"
   end
 
+  def approve
+  end
+
   private
 
   def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,6 @@
 class InterviewsController < ApplicationController
   before_action :set_user, only: [:index, :show]
-  before_action :correct_user, only: [:edit, :update, :destroy]
+  before_action :correct_user, only: [:destroy]
   before_action :different_user, only: [:approve]
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
 
@@ -42,9 +42,12 @@ class InterviewsController < ApplicationController
   end
 
   def approve
-    interview = Interview.find(params[:interview_id])
-    interview.approve_datetime
-    after_update(interview)
+    @interview = Interview.find(params[:interview_id])
+    if @interview.approve_datetime
+      after_update(@interview)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,7 @@
 class InterviewsController < ApplicationController
   before_action :set_user, only: [:index, :show]
   before_action :correct_user, only: [:edit, :update, :destroy]
+  before_action :different_user, only: [:approve]
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -29,7 +30,7 @@ class InterviewsController < ApplicationController
 
   def update
     if @interview.update(interview_params)
-      redirect_to user_interview_path(current_user.id, @interview), notice: "面接が更新されました。"
+      after_update(@interview)
     else
       render :edit
     end
@@ -41,6 +42,9 @@ class InterviewsController < ApplicationController
   end
 
   def approve
+    interview = Interview.find(params[:interview_id])
+    interview.approve_datetime
+    after_update(interview)
   end
 
   private
@@ -57,9 +61,20 @@ class InterviewsController < ApplicationController
     @interview = Interview.find(params[:id])
   end
 
+  def after_update(interview)
+    redirect_to user_interview_path(interview.user.id, interview), notice: "面接が更新されました。"
+  end
+
   def correct_user
     interview = current_user.interviews.find_by(id: params[:id])
     unless interview.present?
+      redirect_to root_url
+    end
+  end
+
+  def different_user
+    interview = current_user.interviews.find_by(id: params[:id])
+    if interview.present?
       redirect_to root_url
     end
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -30,7 +30,7 @@ class InterviewsController < ApplicationController
 
   def update
     if @interview.update(interview_params)
-      after_update(@interview)
+      update_success_redirect(@interview)
     else
       render :edit
     end
@@ -44,7 +44,7 @@ class InterviewsController < ApplicationController
   def approve
     @interview = Interview.find(params[:interview_id])
     if @interview.approve_datetime
-      after_update(@interview)
+      update_success_redirect(@interview)
     else
       render :edit
     end
@@ -64,7 +64,7 @@ class InterviewsController < ApplicationController
     @interview = Interview.find(params[:id])
   end
 
-  def after_update(interview)
+  def update_success_redirect(interview)
     redirect_to user_interview_path(interview.user.id, interview), notice: "面接が更新されました。"
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
   def index
+    @users = User.where.not(id: current_user.id)
   end
 
   def edit

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -13,12 +13,9 @@ class Interview < ApplicationRecord
   end
 
   def approve_datetime
-    if self.update(status: :approval)
-      user = self.user
+    if update(status: :approval)
       interviews = user.interviews.where.not(id: self.id)
-      interviews.each do |interview| 
-        interview.update_attribute(:status, :rejection)
-      end
+      interviews.update_all(status: :rejection)
     end
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,22 +2,35 @@ class Interview < ApplicationRecord
   belongs_to :user
 
   validates :start_datetime, presence: true
-  validate :add_error_start_datetime
+  validate :add_error_start_datetime, on: :create
+  validate :add_error_start_datetime, on: :update
+
   enum status: { reservation: 0, rejection: 1, approval: 2 }
 
   def add_error_start_datetime
     if start_datetime.past?
-      errors.add(:start_datetime, "は未来の時間を指定してください")
+      set_past_error
     end
   end
 
   def approve_datetime
-    self.approval!
-    
-    user = self.user
-    interviews = user.interviews.where.not(id: self.id)
-    interviews.each do |interview|
-      interview.rejection!
+    if self.start_datetime.future?
+      self.update(status: :approval)
+
+      user = self.user
+      interviews = user.interviews.where.not(id: self.id)
+      interviews.each do |interview|
+        interview.update(status: :rejection) 
+      end
+    else
+      set_past_error
+      return false
     end
+  end
+
+  private
+
+  def set_past_error
+    errors.add(:start_datetime, "は未来の時間を指定してください")
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -14,7 +14,7 @@ class Interview < ApplicationRecord
 
   def approve_datetime
     if update(status: :approval)
-      interviews = user.interviews.where.not(id: self.id)
+      interviews = user.interviews.where.not(id: id)
       interviews.update_all(status: :rejection)
     end
   end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -10,4 +10,14 @@ class Interview < ApplicationRecord
       errors.add(:start_datetime, "は未来の時間を指定してください")
     end
   end
+
+  def approve_datetime
+    self.approval!
+    
+    user = self.user
+    interviews = user.interviews.where.not(id: self.id)
+    interviews.each do |interview|
+      interview.rejection!
+    end
+  end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -3,36 +3,22 @@ class Interview < ApplicationRecord
 
   validates :start_datetime, presence: true
   validate :add_error_start_datetime
-  #validate :add_error_start_datetime, on: :update
 
   enum status: { reservation: 0, rejection: 1, approval: 2 }
 
   def add_error_start_datetime
     if start_datetime.past?
-      set_past_error
+      errors.add(:start_datetime, "は未来の時間を指定してください")
     end
   end
 
   def approve_datetime
-    if self.start_datetime.future?
-      self.approval!
-      #self.update!(status: :approval)
-
+    if self.update(status: :approval)
       user = self.user
       interviews = user.interviews.where.not(id: self.id)
-      interviews.each do |interview|
-        #interview.rejection! 
+      interviews.each do |interview| 
         interview.update_attribute(:status, :rejection)
       end
-    else
-      set_past_error
-      return false
     end
-  end
-
-  private
-
-  def set_past_error
-    errors.add(:start_datetime, "は未来の時間を指定してください")
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,8 +2,8 @@ class Interview < ApplicationRecord
   belongs_to :user
 
   validates :start_datetime, presence: true
-  validate :add_error_start_datetime, on: :create
-  validate :add_error_start_datetime, on: :update
+  validate :add_error_start_datetime
+  #validate :add_error_start_datetime, on: :update
 
   enum status: { reservation: 0, rejection: 1, approval: 2 }
 
@@ -15,12 +15,14 @@ class Interview < ApplicationRecord
 
   def approve_datetime
     if self.start_datetime.future?
-      self.update(status: :approval)
+      self.approval!
+      #self.update!(status: :approval)
 
       user = self.user
       interviews = user.interviews.where.not(id: self.id)
       interviews.each do |interview|
-        interview.update(status: :rejection) 
+        #interview.rejection! 
+        interview.update_attribute(:status, :rejection)
       end
     else
       set_past_error

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,6 @@ class User < ApplicationRecord
   has_many :interviews, dependent: :destroy
 
   def age
-    (Date.today.strftime('%Y%m%d').to_i - birth_date.strftime('%Y%m%d').to_i) / 10000
+    (Date.today.strftime('%Y%m%d').to_i - birth_date.strftime('%Y%m%d').to_i) / 10000 if birth_date
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
   enum sex: { woman: 0, man: 1 }
 
   has_many :interviews, dependent: :destroy
+
+  def age
+    (Date.today.strftime('%Y%m%d').to_i - birth_date.strftime('%Y%m%d').to_i) / 10000
+  end
 end

--- a/app/views/interviews/_approval.html.slim
+++ b/app/views/interviews/_approval.html.slim
@@ -9,7 +9,11 @@ h2 現在の面接日程
 
 hr
 
+p 面接日程を変更する場合は以下から選んでください。
+
 - interviews.each do |interview|
+  - if interview.approval?
+    - next
   = form_with url: user_interview_approve_path(user, interview), method: :patch, local: true do |f|
     = button_tag( data: { confirm: "#{interview.start_datetime.to_s(:ja)}で面接を確定してよろしいですか"}, class: "btn btn-secondary") do
       = content_tag :span, interview.start_datetime.to_s(:ja)

--- a/app/views/interviews/_approval.html.slim
+++ b/app/views/interviews/_approval.html.slim
@@ -14,7 +14,7 @@ p 面接日程を変更する場合は以下から選んでください。
 - interviews.each do |interview|
   - if interview.approval?
     - next
-  = form_with url: user_interview_approve_path(user, interview), method: :patch, local: true do |f|
+  = form_with url: user_interview_approve_path(user, interview), method: :put, local: true do |f|
     = button_tag( data: { confirm: "#{interview.start_datetime.to_s(:ja)}で面接を確定してよろしいですか"}, class: "btn btn-secondary") do
       = content_tag :span, interview.start_datetime.to_s(:ja)
   br

--- a/app/views/interviews/_approval.html.slim
+++ b/app/views/interviews/_approval.html.slim
@@ -1,3 +1,16 @@
 h2 現在の面接日程
-p.border_bottom
+- approval_interview = interviews.find_by(status: :approval)
+- if approval_interview.present?
+  p
+    strong = approval_interview.start_datetime.to_s(:ja) 
+    | に設定されています。
+- else
+  p まだ面接開始時間が設定されていません。
 
+hr
+
+- interviews.each do |interview|
+  = form_with url: user_interview_approve_path(user, interview), method: :patch, local: true do |f|
+    = button_tag( data: { confirm: "#{interview.start_datetime.to_s(:ja)}で面接を確定してよろしいですか"}, class: "btn btn-secondary") do
+      = content_tag :span, interview.start_datetime.to_s(:ja)
+  br

--- a/app/views/interviews/_approval.html.slim
+++ b/app/views/interviews/_approval.html.slim
@@ -14,7 +14,7 @@ p 面接日程を変更する場合は以下から選んでください。
 - interviews.each do |interview|
   - if interview.approval?
     - next
-  = form_with url: user_interview_approve_path(user, interview), method: :put, local: true do |f|
+  = form_with url: user_interview_approve_path(user, interview), method: :patch, local: true do |f|
     = button_tag( data: { confirm: "#{interview.start_datetime.to_s(:ja)}で面接を確定してよろしいですか"}, class: "btn btn-secondary") do
       = content_tag :span, interview.start_datetime.to_s(:ja)
   br

--- a/app/views/interviews/_approval.html.slim
+++ b/app/views/interviews/_approval.html.slim
@@ -1,0 +1,3 @@
+h2 現在の面接日程
+p.border_bottom
+

--- a/app/views/interviews/_display.html.slim
+++ b/app/views/interviews/_display.html.slim
@@ -7,7 +7,7 @@ table.table.table-hover
       th
       th
     tbody
-      - @interviews.each do |interview|
+      - interviews.each do |interview|
         tr
           td= interview.start_datetime.to_s(:ja)
           td= interview.status_i18n

--- a/app/views/interviews/_display.html.slim
+++ b/app/views/interviews/_display.html.slim
@@ -11,10 +11,16 @@ table.table.table-hover
         tr
           td= interview.start_datetime.to_s(:ja)
           td= interview.status_i18n
-          td
-            = link_to '編集', edit_user_interview_path(id: interview.id), class: 'btn btn-secondary'
-          td
-            = link_to '削除', user_interview_path(id: interview.id), method: :delete, data: { confirm: "面接日程を削除します。よろしいですか？" }, class: 'btn btn-danger'
+          - if interview.reservation?
+            td
+                = link_to '編集', edit_user_interview_path(id: interview.id), class: 'btn btn-secondary'
+            td
+                = link_to '削除', user_interview_path(id: interview.id), method: :delete, data: { confirm: "面接日程を削除します。よろしいですか？" }, class: 'btn btn-danger'
+          - else
+            td
+                = link_to '編集', edit_user_interview_path(id: interview.id), class: 'btn btn-secondary disabled'
+            td
+                = link_to '削除', user_interview_path(id: interview.id), method: :delete, data: { confirm: "面接日程を削除します。よろしいですか？" }, class: 'btn btn-danger disabled'
 
 
 =link_to '新規面接作成', new_user_interview_path, class: 'btn btn-primary'

--- a/app/views/interviews/_display.html.slim
+++ b/app/views/interviews/_display.html.slim
@@ -1,0 +1,20 @@
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Interview.human_attribute_name(:start_datetime)
+      th= Interview.human_attribute_name(:status)
+      th
+      th
+    tbody
+      - @interviews.each do |interview|
+        tr
+          td= interview.start_datetime.to_s(:ja)
+          td= interview.status_i18n
+          td
+            = link_to '編集', edit_user_interview_path(id: interview.id), class: 'btn btn-secondary'
+          td
+            = link_to '削除', user_interview_path(id: interview.id), method: :delete, data: { confirm: "面接日程を削除します。よろしいですか？" }, class: 'btn btn-danger'
+
+
+=link_to '新規面接作成', new_user_interview_path, class: 'btn btn-primary'

--- a/app/views/interviews/index.html.slim
+++ b/app/views/interviews/index.html.slim
@@ -1,22 +1,6 @@
 h1 #{@user.name}さんの面接一覧
 
-.mb-3
-table.table.table-hover
-  thead.thead-default
-    tr
-      th= Interview.human_attribute_name(:start_datetime)
-      th= Interview.human_attribute_name(:status)
-      th
-      th
-    tbody
-      - @interviews.each do |interview|
-        tr
-          td= interview.start_datetime.to_s(:ja)
-          td= interview.status_i18n
-          td
-            = link_to '編集', edit_user_interview_path(id: interview.id), class: 'btn btn-secondary'
-          td
-            = link_to '削除', user_interview_path(id: interview.id), method: :delete, data: { confirm: "面接日程を削除します。よろしいですか？" }, class: 'btn btn-danger'
-
-
-=link_to '新規面接作成', new_user_interview_path, class: 'btn btn-primary'
+- if @user == current_user
+  =render partial: 'display', locals: { interviews: @interviews }
+- else
+  =render partial: 'approval', locals: { interviews: @interviews }

--- a/app/views/interviews/index.html.slim
+++ b/app/views/interviews/index.html.slim
@@ -3,4 +3,4 @@ h1 #{@user.name}さんの面接一覧
 - if @user == current_user
   =render partial: 'display', locals: { interviews: @interviews }
 - else
-  =render partial: 'approval', locals: { interviews: @interviews }
+  =render partial: 'approval', locals: { interviews: @interviews, user: @user }

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,10 +7,10 @@ html
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   body
-    .app-title.navbar.navbar-expand-md.navbar-light.bg-light
-      .navbar-brand e-Navigator
+    .app-title.navbar.navbar-expand-lg.navbar-light.bg-faded
+      .navbar-brand= link_to 'e-Navigator', users_path, class: 'nav-link'
 
-      ul.navbar-nav.ml-auto
+      ul.navbar-nav.mr-auto
         - if user_signed_in?
           li.nav-item= link_to 'プロフィール', edit_user_registration_path, class: 'nav-link'
           li.nav-item= link_to '自分の面接一覧', user_interviews_path(user_id: current_user.id), class: 'nav-link'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -4,21 +4,24 @@ h1 ユーザー一覧
 table.table.table-hover.table-bordered
   thead.thead-default
     tr
-      th= User.human_attribute_name(:name)
-      th= User.human_attribute_name(:email)
-      th 年齢
-      th= User.human_attribute_name(:sex)
-      th= User.human_attribute_name(:school)
-      th 面接日時
+      th.text-center= User.human_attribute_name(:name)
+      th.text-center= User.human_attribute_name(:email)
+      th.text-center 年齢
+      th.text-center= User.human_attribute_name(:sex)
+      th.text-center= User.human_attribute_name(:school)
+      th.text-center 面接日時
       th
     tbody
       - @users.each do |user|
+        - approval_interview = user.interviews.find_by(status: :approval)
         tr
-          td= user.name
-          td= user.email
-          td= user.age
-          td= user.sex
-          td= user.school
-          td
-          td
+          td.text-center= user.name
+          td.text-center= user.email
+          td.text-center= user.age
+          td.text-center= user.sex
+          td.text-center= user.school
+          td.text-center
+            - if approval_interview.present?
+              = approval_interview.start_datetime.to_s(:ja)
+          td.text-center= link_to '面接一覧', user_interviews_path(user), class: 'btn btn-primary'
 

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,2 +1,24 @@
-h1 Users#index
-p Find me in app/views/users/index.html.slim
+h1 ユーザー一覧
+
+.mb-3
+table.table.table-hover.table-bordered
+  thead.thead-default
+    tr
+      th= User.human_attribute_name(:name)
+      th= User.human_attribute_name(:email)
+      th 年齢
+      th= User.human_attribute_name(:sex)
+      th= User.human_attribute_name(:school)
+      th 面接日時
+      th
+    tbody
+      - @users.each do |user|
+        tr
+          td= user.name
+          td= user.email
+          td= user.age
+          td= user.sex
+          td= user.school
+          td
+          td
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :edit, :update] do
     resources :interviews do
-      put :approve
+      patch :approve
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
   root to: 'users#index'
 
   resources :users, only: [:index, :edit, :update] do
-      resources :interviews do
-          patch :approve
-      end
+    resources :interviews do
+      put :approve
+    end
   end
 
   devise_for :users, controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   root to: 'users#index'
 
   resources :users, only: [:index, :edit, :update] do
-      resources :interviews
+      resources :interviews do
+          patch :approve
+      end
   end
 
   devise_for :users, controllers: {


### PR DESCRIPTION
やりたかったこと
---
- トップページに自分以外のユーザーの表示
- 面接官用の面接日程一覧ページの作成
- 面接日程を承認or拒否できるようにする

やったこと
----
- ユーザー一覧表示機能の実装
- ログインユーザーの面接日程かどうかで表示内容の切り替え
- 面接日程の承認画面の実装
- 承認機能の実装
- 自分の面接一覧を表示したときに保留の面接のみ、編集・削除ができるように変更
- ナビバーの変更（トップページへリンクの追加）

動作確認方法
---
- [ ] ログインし、トップページに自分以外のユーザー一覧が表示されていることを確認する
- [ ] 面接一覧から面接日程を確定する
- [ ] 再度面接一覧にいき、設定した面接日程になっていることを確認する
- [ ] 自分の面接一覧にいく
- [ ] 他のユーザーの面接一覧画面と表示内容が違うことを確認する
- [ ] 新規面接を作成する
- [ ] 保留の面接以外は、編集と削除のリンクが不活性になっていることを確認する

その他
---
よろしくお願いします。